### PR TITLE
Prevent panic from malformed Mic-E

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -263,7 +263,10 @@ func (p *Packet) parse() error {
 			return err
 		}
 		p.Position = &pos
-		p.parseMicEData()
+		err = p.parseMicEData()
+		if err != nil {
+			return err
+		}
 
 		return nil // there is no additional data to parse
 	default:
@@ -295,6 +298,12 @@ func (p *Packet) parseMicEData() error {
 	var t string
 	for i := 0; i < 3; i++ {
 		mc := miceCodes[rune(p.Dst.Call[i])][1]
+
+		if len(mc) == 0 {
+			// Malformed Mic-E packet, prevent index out of bounds.
+			return ErrInvalidPacket
+		}
+
 		if strings.HasSuffix(mc, "(Custom)") {
 			t = messageTypeCustom
 		} else if strings.HasSuffix(mc, "(Std)") {

--- a/packet_test.go
+++ b/packet_test.go
@@ -29,6 +29,15 @@ func testDistance(a *Position, b *Position) float64 {
 	return 2 * earthRadius * math.Asin(math.Sqrt(h))
 }
 
+func TestBadPacket(t *testing.T) {
+	raw := "N0CALL-9>P_0_P?,N0CALL-3*,WIDE1*,N0CALL-13*,N0CALL-10*,WIDE2*:'{g+l >/Test"
+	_, err := ParsePacket(raw)
+
+	if err == nil {
+		t.Fatalf("Expected an error parsing a bad Mic-E packet.")
+	}
+}
+
 func TestPacket(t *testing.T) {
 	var tests = []struct {
 		Raw      string


### PR DESCRIPTION
Handles #5 gracefully with a friendly error rather than panic.